### PR TITLE
Updated luautf8 to use actually modern versions (scm-0 does not compile)

### DIFF
--- a/lwtk-scm-0.rockspec
+++ b/lwtk-scm-0.rockspec
@@ -14,7 +14,7 @@ description = {
 dependencies = {
     "lua >= 5.1, <= 5.4",
     "compat53",
-    "luautf8",
+    "luautf8 >= 0.1.4",
     "lpugl_cairo"
 }
 build = {


### PR DESCRIPTION
This fixes an issue with the `LUA_QL` macro which caused a compile error.